### PR TITLE
Handle inbound Telnyx call events

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ app.post("/webhook", async (req, res) => {
     console.log("Webhook:", event);
 
     // Alku: vastaa kun puhelu alkaa
-    if (event === "call.initiated") {
+    if (event === "call.initiated" || event === "call.incoming") {
       conversations[callId] = [
         { role: "system", content: "Olet ystävällinen asiakaspalvelija. Vastaat selkeästi ja kysyt tarvittaessa lisätietoja." }
       ];
@@ -69,6 +69,12 @@ app.post("/webhook", async (req, res) => {
 
       if (!transcript) {
         return res.json({ data: { result: "noop" } });
+      }
+
+      if (!conversations[callId]) {
+        conversations[callId] = [
+          { role: "system", content: "Olet ystävällinen asiakaspalvelija. Vastaat selkeästi ja kysyt tarvittaessa lisätietoja." }
+        ];
       }
 
       conversations[callId].push({ role: "user", content: transcript });


### PR DESCRIPTION
## Summary
- answer Telnyx calls on both call.initiated and call.incoming events so inbound calls open the line
- initialize a default system prompt if speech events arrive before the conversation has been set up

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68caa272348c83238d155504f9cb0fb0